### PR TITLE
Update gtk-widgets-assets.css

### DIFF
--- a/gtk-3.0/gtk-widgets-assets.css
+++ b/gtk-3.0/gtk-widgets-assets.css
@@ -5,119 +5,142 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
+    -gtk-icon-source: url("assets/checkbox-unchecked.png");
     background-image: url("assets/checkbox-unchecked.png");
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
+    -gtk-icon-source: url("assets/checkbox-unchecked-insensitive.png");
     background-image: url("assets/checkbox-unchecked-insensitive.png");
 }
 
-.check:active,
+.check:active, .check:checked,
 .check row:selected:active,
-.check row:selected:focus:active {
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: url("assets/checkbox-checked.png");
     background-image: url("assets/checkbox-checked.png");
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: url("assets/checkbox-checked-insensitive.png");
     background-image: url("assets/checkbox-checked-insensitive.png");
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
+    -gtk-icon-source: url("assets/checkbox-mixed.png");
     background-image: url("assets/checkbox-mixed.png");
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
+    -gtk-icon-source: url("assets/checkbox-mixed-insensitive.png");
     background-image: url("assets/checkbox-mixed-insensitive.png");
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
+    -gtk-icon-source: url("assets/radio-unselected.png");
     background-image: url("assets/radio-unselected.png");
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
+    -gtk-icon-source: url("assets/radio-unselected-insensitive.png");
     background-image: url("assets/radio-unselected-insensitive.png");
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: url("assets/radio-selected.png");
     background-image: url("assets/radio-selected.png");
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: url("assets/radio-selected-insensitive.png");
     background-image: url("assets/radio-selected-insensitive.png");
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
+    -gtk-icon-source: url("assets/radio-mixed.png");
     background-image: url("assets/radio-mixed.png");
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
+    -gtk-icon-source: url("assets/radio-mixed-insensitive.png");
     background-image: url("assets/radio-mixed-insensitive.png");
 }
 
-.menuitem.check:active {
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked.png");
     background-image: url("assets/menuitem-checkbox-checked.png");
 }
 
-.menuitem.check:active:hover {
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked-hover.png");
     background-image: url("assets/menuitem-checkbox-checked-hover.png");
 }
 
-.menuitem.check:active:insensitive {
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked-insensitive.png");
     background-image: url("assets/menuitem-checkbox-checked-insensitive.png");
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed-hover.png");
     background-image: url("assets/menuitem-checkbox-mixed-hover.png");
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed.png");
     background-image: url("assets/menuitem-checkbox-mixed.png");
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed-insensitive.png");
     background-image: url("assets/menuitem-checkbox-mixed-insensitive.png");
 }
 
-.menuitem.radio:active {
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: url("assets/menuitem-radio-checked.png");
     background-image: url("assets/menuitem-radio-checked.png");
 }
 
-.menuitem.radio:active:hover {
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: url("assets/menuitem-radio-checked-hover.png");
     background-image: url("assets/menuitem-radio-checked-hover.png");
 }
 
-.menuitem.radio:active:insensitive {
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: url("assets/menuitem-radio-checked-insensitive.png");
     background-image: url("assets/menuitem-radio-checked-insensitive.png");
 }
 
 GtkIconView.content-view.cell.check {
+    -gtk-icon-source: url("assets/grid-selection-unchecked.png");
     background-image: url("assets/grid-selection-unchecked.png");
 }
 
-GtkIconView.content-view.cell.check:active {
+GtkIconView.content-view.cell.check:active, GtkIconView.content-view.cell.check:checked {
+    -gtk-icon-source: url("assets/grid-selection-checked.png");
     background-image: url("assets/grid-selection-checked.png");
 }
 


### PR DESCRIPTION
test for gnome/gtk 3.14
mix with murrine-theme debian sid
keep old denomination for assets (backround-image)