### PR TITLE
Add index.theme

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=X-GNOME-Metatheme
+Name=Bluebird
+Comment=Bluebird theme
+Encoding=UTF-8
+
+[X-GNOME-Metatheme]
+GtkTheme=Bluebird
+MetacityTheme=Bluebird
+IconTheme=Adwaita
+CursorTheme=Adwaita
+ButtonLayout=:minimize,maximize,close


### PR DESCRIPTION
If we want Bluebird to show up in Mate's theme picker (mate-appearance-properties), we need to add an index.theme.

I suggest using Adwaita for the cursor and icon themes since it should be installed everywhere. (The Elementary icon themes still aren't packaged in Debian.) These defaults should only affect MATE. (There is an XFCE theme manager [app](http://www.webupd8.org/2013/06/xfce-theme-manager-single-gui-to-change.html) that I haven't tested that might use these defaults too.)

Here's what it looks like if users don't have the icon-theme installed:
![numix-missing-icon-theme](https://cloud.githubusercontent.com/assets/876259/16136806/d7dc7a82-33fb-11e6-8c91-4b3501d46cad.png)

However, the Adwaita cursor theme is not installed in Ubuntu 16.04 LTS by default; users will need to install adwaita-icon-theme-full. (I intend to fix that for 16.10 and I might SRU it for 16.04.)
