### PR TITLE
README: Bluebird uses sassc, not Ruby Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The Gtk+3 theme uses the builtin engine and consequently has no dependencies.
 ### Build dependencies ###
 Debian or Ubuntu:
 
-`sudo apt install autoconf libgdk-pixbuf2.0-dev libglib2.0-bin librsvg2-dev ruby-sass sassc`
+`sudo apt install autoconf libgdk-pixbuf2.0-dev librsvg2-dev sassc`
 
 Fedora:
 
-`dnf install gdk-pixbuf2-devel librsvg2-devel rubygem-sass`
+`dnf install gdk-pixbuf2-devel librsvg2-devel sassc`
 
 ### Install without admin privileges
 


### PR DESCRIPTION
I updated the Debian/Ubuntu packaging and noticed this minor issue.

Thanks for working on this theme!